### PR TITLE
Add OrderStatus enum and integrate with Order record

### DIFF
--- a/src/main/java/Order.java
+++ b/src/main/java/Order.java
@@ -1,7 +1,7 @@
 import java.util.List;
 
 public record Order(
-        String id,
-        List<Product> products
-) {
+                String id,
+                List<Product> products,
+                OrderStatus status) {
 }

--- a/src/main/java/OrderStatus.java
+++ b/src/main/java/OrderStatus.java
@@ -1,0 +1,15 @@
+public enum OrderStatus {
+    PROCESSING("Processing"),
+    IN_DELIVERY("In Delivery"),
+    COMPLETED("Completed");
+
+    String value;
+
+    OrderStatus(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/src/main/java/ShopService.java
+++ b/src/main/java/ShopService.java
@@ -17,7 +17,7 @@ public class ShopService {
             products.add(productToOrder);
         }
 
-        Order newOrder = new Order(UUID.randomUUID().toString(), products);
+        Order newOrder = new Order(UUID.randomUUID().toString(), products, OrderStatus.PROCESSING);
 
         return orderRepo.addOrder(newOrder);
     }

--- a/src/test/java/OrderListRepoTest.java
+++ b/src/test/java/OrderListRepoTest.java
@@ -1,77 +1,77 @@
-import org.junit.jupiter.api.Test;
-
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import org.junit.jupiter.api.Test;
 
 class OrderListRepoTest {
 
     @Test
     void getOrders() {
-        //GIVEN
+        // GIVEN
         OrderListRepo repo = new OrderListRepo();
 
         Product product = new Product("1", "Apfel");
-        Order newOrder = new Order("1", List.of(product));
+        Order newOrder = new Order("1", List.of(product), OrderStatus.PROCESSING);
         repo.addOrder(newOrder);
 
-        //WHEN
+        // WHEN
         List<Order> actual = repo.getOrders();
 
-        //THEN
+        // THEN
         List<Order> expected = new ArrayList<>();
         Product product1 = new Product("1", "Apfel");
-        expected.add(new Order("1", List.of(product1)));
+        expected.add(new Order("1", List.of(product1), OrderStatus.PROCESSING));
 
         assertEquals(actual, expected);
     }
 
     @Test
     void getOrderById() {
-        //GIVEN
+        // GIVEN
         OrderListRepo repo = new OrderListRepo();
 
         Product product = new Product("1", "Apfel");
-        Order newOrder = new Order("1", List.of(product));
+        Order newOrder = new Order("1", List.of(product), OrderStatus.PROCESSING);
         repo.addOrder(newOrder);
 
-        //WHEN
+        // WHEN
         Order actual = repo.getOrderById("1");
 
-        //THEN
+        // THEN
         Product product1 = new Product("1", "Apfel");
-        Order expected = new Order("1", List.of(product1));
+        Order expected = new Order("1", List.of(product1), OrderStatus.PROCESSING);
 
         assertEquals(actual, expected);
     }
 
     @Test
     void addOrder() {
-        //GIVEN
+        // GIVEN
         OrderListRepo repo = new OrderListRepo();
         Product product = new Product("1", "Apfel");
-        Order newOrder = new Order("1", List.of(product));
+        Order newOrder = new Order("1", List.of(product), OrderStatus.PROCESSING);
 
-        //WHEN
+        // WHEN
         Order actual = repo.addOrder(newOrder);
 
-        //THEN
+        // THEN
         Product product1 = new Product("1", "Apfel");
-        Order expected = new Order("1", List.of(product1));
+        Order expected = new Order("1", List.of(product1), OrderStatus.PROCESSING);
         assertEquals(actual, expected);
         assertEquals(repo.getOrderById("1"), expected);
     }
 
     @Test
     void removeOrder() {
-        //GIVEN
+        // GIVEN
         OrderListRepo repo = new OrderListRepo();
 
-        //WHEN
+        // WHEN
         repo.removeOrder("1");
 
-        //THEN
+        // THEN
         assertNull(repo.getOrderById("1"));
     }
 }

--- a/src/test/java/OrderMapRepoTest.java
+++ b/src/test/java/OrderMapRepoTest.java
@@ -1,77 +1,77 @@
-import org.junit.jupiter.api.Test;
-
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import org.junit.jupiter.api.Test;
 
 class OrderMapRepoTest {
 
     @Test
     void getOrders() {
-        //GIVEN
+        // GIVEN
         OrderMapRepo repo = new OrderMapRepo();
 
         Product product = new Product("1", "Apfel");
-        Order newOrder = new Order("1", List.of(product));
+        Order newOrder = new Order("1", List.of(product), OrderStatus.PROCESSING);
         repo.addOrder(newOrder);
 
-        //WHEN
+        // WHEN
         List<Order> actual = repo.getOrders();
 
-        //THEN
+        // THEN
         List<Order> expected = new ArrayList<>();
         Product product1 = new Product("1", "Apfel");
-        expected.add(new Order("1", List.of(product1)));
+        expected.add(new Order("1", List.of(product1), OrderStatus.PROCESSING));
 
         assertEquals(actual, expected);
     }
 
     @Test
     void getOrderById() {
-        //GIVEN
+        // GIVEN
         OrderMapRepo repo = new OrderMapRepo();
 
         Product product = new Product("1", "Apfel");
-        Order newOrder = new Order("1", List.of(product));
+        Order newOrder = new Order("1", List.of(product), OrderStatus.PROCESSING);
         repo.addOrder(newOrder);
 
-        //WHEN
+        // WHEN
         Order actual = repo.getOrderById("1");
 
-        //THEN
+        // THEN
         Product product1 = new Product("1", "Apfel");
-        Order expected = new Order("1", List.of(product1));
+        Order expected = new Order("1", List.of(product1), OrderStatus.PROCESSING);
 
         assertEquals(actual, expected);
     }
 
     @Test
     void addOrder() {
-        //GIVEN
+        // GIVEN
         OrderMapRepo repo = new OrderMapRepo();
         Product product = new Product("1", "Apfel");
-        Order newOrder = new Order("1", List.of(product));
+        Order newOrder = new Order("1", List.of(product), OrderStatus.PROCESSING);
 
-        //WHEN
+        // WHEN
         Order actual = repo.addOrder(newOrder);
 
-        //THEN
+        // THEN
         Product product1 = new Product("1", "Apfel");
-        Order expected = new Order("1", List.of(product1));
+        Order expected = new Order("1", List.of(product1), OrderStatus.PROCESSING);
         assertEquals(actual, expected);
         assertEquals(repo.getOrderById("1"), expected);
     }
 
     @Test
     void removeOrder() {
-        //GIVEN
+        // GIVEN
         OrderMapRepo repo = new OrderMapRepo();
 
-        //WHEN
+        // WHEN
         repo.removeOrder("1");
 
-        //THEN
+        // THEN
         assertNull(repo.getOrderById("1"));
     }
 }

--- a/src/test/java/ShopServiceTest.java
+++ b/src/test/java/ShopServiceTest.java
@@ -1,36 +1,37 @@
-import org.junit.jupiter.api.Test;
-
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import org.junit.jupiter.api.Test;
 
 class ShopServiceTest {
 
     @Test
     void addOrderTest() {
-        //GIVEN
+        // GIVEN
         ShopService shopService = new ShopService();
         List<String> productsIds = List.of("1");
 
-        //WHEN
+        // WHEN
         Order actual = shopService.addOrder(productsIds);
 
-        //THEN
-        Order expected = new Order("-1", List.of(new Product("1", "Apfel")));
+        // THEN
+        Order expected = new Order("-1", List.of(new Product("1", "Apfel")), OrderStatus.PROCESSING);
         assertEquals(expected.products(), actual.products());
         assertNotNull(expected.id());
     }
 
     @Test
     void addOrderTest_whenInvalidProductId_expectNull() {
-        //GIVEN
+        // GIVEN
         ShopService shopService = new ShopService();
         List<String> productsIds = List.of("1", "2");
 
-        //WHEN
+        // WHEN
         Order actual = shopService.addOrder(productsIds);
 
-        //THEN
+        // THEN
         assertNull(actual);
     }
 }


### PR DESCRIPTION
Introduce an OrderStatus enum to represent the status of an order and update the Order record to include this status. Modify all instances of the Order constructor to initialize with a default status of PROCESSING.