### PR TITLE
Change getProductById to return Optional<Product>

### DIFF
--- a/src/main/java/ProductRepo.java
+++ b/src/main/java/ProductRepo.java
@@ -1,5 +1,6 @@
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 public class ProductRepo {
     private List<Product> products;
@@ -13,13 +14,8 @@ public class ProductRepo {
         return products;
     }
 
-    public Product getProductById(String id) {
-        for (Product product : products) {
-            if (product.id().equals(id)) {
-                return product;
-            }
-        }
-        return null;
+    public Optional<Product> getProductById(String id) {
+        return products.stream().filter(p -> id.equals(p.id())).findFirst();
     }
 
     public Product addProduct(Product newProduct) {
@@ -29,10 +25,10 @@ public class ProductRepo {
 
     public void removeProduct(String id) {
         for (Product product : products) {
-           if (product.id().equals(id)) {
-               products.remove(product);
-               return;
-           }
+            if (product.id().equals(id)) {
+                products.remove(product);
+                return;
+            }
         }
     }
 }

--- a/src/main/java/ShopService.java
+++ b/src/main/java/ShopService.java
@@ -1,5 +1,6 @@
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public class ShopService {
@@ -8,13 +9,14 @@ public class ShopService {
 
     public Order addOrder(List<String> productIds) {
         List<Product> products = new ArrayList<>();
+
         for (String productId : productIds) {
-            Product productToOrder = productRepo.getProductById(productId);
-            if (productToOrder == null) {
+            Optional<Product> productToOrder = productRepo.getProductById(productId);
+            if (productToOrder.isEmpty()) {
                 System.out.println("Product mit der Id: " + productId + " konnte nicht bestellt werden!");
                 return null;
             }
-            products.add(productToOrder);
+            products.add(productToOrder.get());
         }
 
         Order newOrder = new Order(UUID.randomUUID().toString(), products, OrderStatus.PROCESSING);

--- a/src/test/java/ProductRepoTest.java
+++ b/src/test/java/ProductRepoTest.java
@@ -4,7 +4,6 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import org.junit.jupiter.api.Test;
 
 class ProductRepoTest {
@@ -55,7 +54,7 @@ class ProductRepoTest {
         // THEN
         Product expected = new Product("2", "Banane");
         assertEquals(actual, expected);
-        assertEquals(repo.getProductById("2"), expected);
+        assertEquals(repo.getProductById("2").get(), expected);
     }
 
     @Test
@@ -67,6 +66,6 @@ class ProductRepoTest {
         repo.removeProduct("1");
 
         // THEN
-        assertNull(repo.getProductById("1"));
+        assertThat(repo.getProductById("1")).isEmpty();
     }
 }

--- a/src/test/java/ProductRepoTest.java
+++ b/src/test/java/ProductRepoTest.java
@@ -1,12 +1,15 @@
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import org.junit.jupiter.api.Test;
 
 class ProductRepoTest {
 
-    @org.junit.jupiter.api.Test
+    @Test
     void getProducts() {
         // GIVEN
         ProductRepo repo = new ProductRepo();
@@ -20,20 +23,27 @@ class ProductRepoTest {
         assertEquals(actual, expected);
     }
 
-    @org.junit.jupiter.api.Test
-    void getProductById() {
+    @Test
+    void getProductById_returnsProduct_withValidId() {
         // GIVEN
         ProductRepo repo = new ProductRepo();
 
         // WHEN
-        Product actual = repo.getProductById("1");
+        Optional<Product> actual = repo.getProductById("1");
 
         // THEN
         Product expected = new Product("1", "Apfel");
-        assertEquals(actual, expected);
+        assertThat(actual).isNotEmpty().contains(expected);
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
+    void getProductById_returnsEmpty_withInvalidId() {
+        ProductRepo repo = new ProductRepo();
+        Optional<Product> actual = repo.getProductById("2");
+        assertThat(actual).isEmpty();
+    }
+
+    @Test
     void addProduct() {
         // GIVEN
         ProductRepo repo = new ProductRepo();
@@ -48,7 +58,7 @@ class ProductRepoTest {
         assertEquals(repo.getProductById("2"), expected);
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void removeProduct() {
         // GIVEN
         ProductRepo repo = new ProductRepo();


### PR DESCRIPTION
Update the return type of getProductById to Optional<Product> for better null safety, modify all related calls accordingly, and enhance tests to cover both valid and invalid product IDs.