### PR TITLE
Add ProductNotFoundException for invalid product IDs in orders

### DIFF
--- a/src/main/java/ProductNotFoundException.java
+++ b/src/main/java/ProductNotFoundException.java
@@ -1,0 +1,5 @@
+public class ProductNotFoundException extends Exception {
+    public ProductNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/ShopService.java
+++ b/src/main/java/ShopService.java
@@ -7,14 +7,14 @@ public class ShopService {
     private final ProductRepo productRepo = new ProductRepo();
     private final OrderRepo orderRepo = new OrderMapRepo();
 
-    public Order addOrder(List<String> productIds) {
+    public Order addOrder(List<String> productIds) throws ProductNotFoundException {
         List<Product> products = new ArrayList<>();
 
         for (String productId : productIds) {
             Optional<Product> productToOrder = productRepo.getProductById(productId);
             if (productToOrder.isEmpty()) {
-                System.out.println("Product mit der Id: " + productId + " konnte nicht bestellt werden!");
-                return null;
+                throw new ProductNotFoundException("No product with an id of " + productId + " was found.");
+
             }
             products.add(productToOrder.get());
         }

--- a/src/test/java/ShopServiceTest.java
+++ b/src/test/java/ShopServiceTest.java
@@ -1,62 +1,58 @@
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class ShopServiceTest {
 
+    ShopService service;
+    List<String> ids;
+    Order order;
+
+    @BeforeEach
+    @SuppressWarnings("unused")
+    void setUp() throws ProductNotFoundException {
+        service = new ShopService();
+        ids = new ArrayList<>();
+        ids.add("1");
+        order = service.addOrder(ids);
+    }
+
     @Test
-    void addOrderTest() {
-        // GIVEN
-        ShopService shopService = new ShopService();
-        List<String> productsIds = List.of("1");
-
-        // WHEN
-        Order actual = shopService.addOrder(productsIds);
-
-        // THEN
+    void addOrder_returnsAddedOrder_givenValidIds() throws ProductNotFoundException {
+        Order actual = service.addOrder(ids);
         Order expected = new Order("-1", List.of(new Product("1", "Apfel")), OrderStatus.PROCESSING);
         assertEquals(expected.products(), actual.products());
         assertNotNull(expected.id());
     }
 
     @Test
-    void addOrderTest_whenInvalidProductId_expectNull() {
-        // GIVEN
-        ShopService shopService = new ShopService();
-        List<String> productsIds = List.of("1", "2");
+    void addOrderTest_throwsProductNotFoundException_withInvalidId() {
+        String invalidId = "2";
+        ids.add(invalidId);
 
-        // WHEN
-        Order actual = shopService.addOrder(productsIds);
-
-        // THEN
-        assertNull(actual);
+        assertThatThrownBy(() -> {
+            service.addOrder(ids);
+        }).isInstanceOf(ProductNotFoundException.class)
+                .hasMessage("No product with an id of " + invalidId + " was found.");
     }
 
     @Test
-    void getOrdersWithStatus_returnsMatchingProducts_whenStatusIsPresent() {
-        ShopService shopService = new ShopService();
-        List<String> productsIds = List.of("1");
+    void getOrdersWithStatus_returnsMatchingProducts_whenStatusIsPresent() throws ProductNotFoundException {
+        Order order1 = service.addOrder(ids);
 
-        Order order1 = shopService.addOrder(productsIds);
-        Order order2 = shopService.addOrder(productsIds);
-
-        assertThat(shopService.getOrdersWithStatus(OrderStatus.PROCESSING))
-                .containsExactlyInAnyOrder(order1, order2);
+        assertThat(service.getOrdersWithStatus(OrderStatus.PROCESSING))
+                .containsExactlyInAnyOrder(order1, order);
     }
 
     @Test
     void getOrderWithStatus_returnsEmptyList_whenStatusIsNotPresent() {
-        ShopService shopService = new ShopService();
-        List<String> productsIds = List.of("1");
-
-        shopService.addOrder(productsIds);
-
-        assertThat(shopService.getOrdersWithStatus(OrderStatus.COMPLETED)).isEmpty();
-
+        assertThat(service.getOrdersWithStatus(OrderStatus.COMPLETED)).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
Introduce a new exception for handling cases where an invalid product ID is provided when adding an order. Update tests to validate this behavior and ensure proper exception handling.