### PR TITLE
Add timestamp to Order records and update related services

### DIFF
--- a/src/main/java/Order.java
+++ b/src/main/java/Order.java
@@ -1,10 +1,12 @@
+import java.time.Instant;
 import java.util.List;
 
 import lombok.With;
 
 @With
 public record Order(
-        String id,
-        List<Product> products,
-        OrderStatus status) {
+                String id,
+                List<Product> products,
+                OrderStatus status,
+                Instant timestamp) {
 }

--- a/src/main/java/ShopService.java
+++ b/src/main/java/ShopService.java
@@ -1,3 +1,4 @@
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -19,7 +20,7 @@ public class ShopService {
             products.add(productToOrder.get());
         }
 
-        Order newOrder = new Order(UUID.randomUUID().toString(), products, OrderStatus.PROCESSING);
+        Order newOrder = new Order(UUID.randomUUID().toString(), products, OrderStatus.PROCESSING, Instant.now());
 
         return orderRepo.addOrder(newOrder);
     }

--- a/src/test/java/OrderListRepoTest.java
+++ b/src/test/java/OrderListRepoTest.java
@@ -1,78 +1,55 @@
-import java.util.ArrayList;
+import java.time.Instant;
 import java.util.List;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class OrderListRepoTest {
+    OrderRepo repo;
+    Product product;
+    Order order;
+
+    @BeforeEach
+    void setUp() {
+        repo = new OrderListRepo();
+        product = new Product("P1", "Apple");
+        order = new Order("O1", List.of(product), OrderStatus.PROCESSING, Instant.now());
+        repo.addOrder(order);
+    }
 
     @Test
     void getOrders() {
-        // GIVEN
-        OrderListRepo repo = new OrderListRepo();
-
-        Product product = new Product("1", "Apfel");
-        Order newOrder = new Order("1", List.of(product), OrderStatus.PROCESSING);
-        repo.addOrder(newOrder);
-
-        // WHEN
-        List<Order> actual = repo.getOrders();
-
-        // THEN
-        List<Order> expected = new ArrayList<>();
-        Product product1 = new Product("1", "Apfel");
-        expected.add(new Order("1", List.of(product1), OrderStatus.PROCESSING));
-
-        assertEquals(actual, expected);
+        assertThat(repo.getOrders())
+                .containsExactly(order);
     }
 
     @Test
     void getOrderById() {
-        // GIVEN
-        OrderListRepo repo = new OrderListRepo();
-
-        Product product = new Product("1", "Apfel");
-        Order newOrder = new Order("1", List.of(product), OrderStatus.PROCESSING);
-        repo.addOrder(newOrder);
-
-        // WHEN
-        Optional<Order> actual = repo.getOrderById("1");
-
-        // THEN
-        Product product1 = new Product("1", "Apfel");
-        Order expected = new Order("1", List.of(product1), OrderStatus.PROCESSING);
-
-        assertEquals(actual.get(), expected);
+        assertThat(repo.getOrderById("O1"))
+                .contains(order);
     }
 
     @Test
     void addOrder() {
-        // GIVEN
-        OrderListRepo repo = new OrderListRepo();
-        Product product = new Product("1", "Apfel");
-        Order newOrder = new Order("1", List.of(product), OrderStatus.PROCESSING);
-
         // WHEN
-        Order actual = repo.addOrder(newOrder);
+        repo.removeOrder("O1");
+        Order actual = repo.addOrder(order);
 
         // THEN
-        Product product1 = new Product("1", "Apfel");
-        Order expected = new Order("1", List.of(product1), OrderStatus.PROCESSING);
-        assertEquals(actual, expected);
-        assertEquals(repo.getOrderById("1").get(), expected);
+        assertThat(actual)
+                .isEqualTo(order);
+        assertThat(repo.getOrderById("O1"))
+                .containsSame(order);
+
     }
 
     @Test
     void removeOrder() {
-        // GIVEN
-        OrderListRepo repo = new OrderListRepo();
-
         // WHEN
-        repo.removeOrder("1");
+        repo.removeOrder("O1");
 
         // THEN
-        assertThat(repo.getOrderById("1")).isEmpty();
+        assertThat(repo.getOrderById("O1")).isEmpty();
     }
 }

--- a/src/test/java/OrderMapRepoTest.java
+++ b/src/test/java/OrderMapRepoTest.java
@@ -1,78 +1,53 @@
-import java.util.ArrayList;
+import java.time.Instant;
 import java.util.List;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class OrderMapRepoTest {
+    OrderRepo repo;
+    Product product;
+    Order order;
+
+    @BeforeEach
+    void setUp() {
+        repo = new OrderMapRepo();
+        product = new Product("P1", "Apple");
+        order = new Order("O1", List.of(product), OrderStatus.PROCESSING, Instant.now());
+        repo.addOrder(order);
+    }
 
     @Test
     void getOrders() {
-        // GIVEN
-        OrderMapRepo repo = new OrderMapRepo();
-
-        Product product = new Product("1", "Apfel");
-        Order newOrder = new Order("1", List.of(product), OrderStatus.PROCESSING);
-        repo.addOrder(newOrder);
-
-        // WHEN
-        List<Order> actual = repo.getOrders();
-
-        // THEN
-        List<Order> expected = new ArrayList<>();
-        Product product1 = new Product("1", "Apfel");
-        expected.add(new Order("1", List.of(product1), OrderStatus.PROCESSING));
-
-        assertEquals(actual, expected);
+        assertThat(repo.getOrders())
+                .containsExactly(order);
     }
 
     @Test
     void getOrderById() {
-        // GIVEN
-        OrderMapRepo repo = new OrderMapRepo();
-
-        Product product = new Product("1", "Apfel");
-        Order newOrder = new Order("1", List.of(product), OrderStatus.PROCESSING);
-        repo.addOrder(newOrder);
-
-        // WHEN
-        Optional<Order> actual = repo.getOrderById("1");
-
-        // THEN
-        Product product1 = new Product("1", "Apfel");
-        Order expected = new Order("1", List.of(product1), OrderStatus.PROCESSING);
-
-        assertEquals(actual.get(), expected);
+        assertThat(repo.getOrderById("O1"))
+                .contains(order);
     }
 
     @Test
     void addOrder() {
-        // GIVEN
-        OrderMapRepo repo = new OrderMapRepo();
-        Product product = new Product("1", "Apfel");
-        Order newOrder = new Order("1", List.of(product), OrderStatus.PROCESSING);
-
-        // WHEN
-        Order actual = repo.addOrder(newOrder);
-
         // THEN
-        Product product1 = new Product("1", "Apfel");
-        Order expected = new Order("1", List.of(product1), OrderStatus.PROCESSING);
-        assertEquals(actual, expected);
-        assertEquals(repo.getOrderById("1").get(), expected);
+        repo.removeOrder("O1");
+        Order actual = repo.addOrder(order);
+
+        assertThat(actual)
+                .isEqualTo(order);
+        assertThat(repo.getOrderById("O1"))
+                .containsSame(order);
     }
 
     @Test
     void removeOrder() {
-        // GIVEN
-        OrderMapRepo repo = new OrderMapRepo();
-
-        // WHEN
-        repo.removeOrder("1");
+        repo.removeOrder("O1");
 
         // THEN
-        assertThat(repo.getOrderById("1")).isEmpty();
+        assertThat(repo.getOrderById("O1"))
+                .isEmpty();
     }
 }

--- a/src/test/java/ShopServiceTest.java
+++ b/src/test/java/ShopServiceTest.java
@@ -1,3 +1,4 @@
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -26,7 +27,7 @@ class ShopServiceTest {
     @Test
     void addOrder_returnsAddedOrder_givenValidIds() throws ProductNotFoundException {
         Order actual = service.addOrder(ids);
-        Order expected = new Order("-1", List.of(new Product("1", "Apfel")), OrderStatus.PROCESSING);
+        Order expected = new Order("-1", List.of(new Product("1", "Apfel")), OrderStatus.PROCESSING, Instant.now());
         assertEquals(expected.products(), actual.products());
         assertNotNull(expected.id());
     }


### PR DESCRIPTION
Introduce an Instant timestamp to the Order record, updating the ShopService to utilize the new constructor. Adjust tests for OrderRepo and ShopService to accommodate these changes.